### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime
+ENV DEBIAN_FRONTEND=noninteractive 
+
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
+
+# Create a conda aloha env
+RUN conda create --name aloha python=3.8.10 && \
+    echo "source activate aloha" > ~/.bashrc
+
+# Set the PATH for the new environment
+ENV PATH /opt/conda/envs/aloha/bin:$PATH
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    vim \ 
+    git
+
+RUN /opt/conda/envs/aloha/bin/python -m pip install \
+    torchvision \
+    torch \
+    pyquaternion \
+    pyyaml \
+    rospkg \
+    pexpect \
+    mujoco \
+    dm_control \
+    opencv-python \
+    matplotlib \
+    einops \
+    packaging \
+    h5py \
+    ipython
+
+# WORKDIR act-plus-plus/detr
+COPY detr /detr
+WORKDIR /detr
+RUN /opt/conda/envs/aloha/bin/python -m pip install -e .
+
+RUN apt-get update && apt-get install -y libglib2.0-0
+
+# Set the working directory
+WORKDIR /tempdir
+
+# Uninstall robomimic if it's installed
+RUN pip uninstall -y robomimic
+RUN git clone https://github.com/ARISE-Initiative/robomimic.git
+
+# Change into the robomimic directory and checkout the desired branch
+WORKDIR /tempdir/robomimic
+RUN git checkout diffusion-policy-mg
+
+# Install robomimic and diffusers
+RUN pip install -e . && pip install diffusers
+WORKDIR /act-plus-plus

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ You can find all scripted/human demo for simulated environments [here](https://d
     pip install ipython
     cd act/detr && pip install -e .
 
+### Docker and Remote Development
+These instructions were written for both training and generating synthethic data on a remote box with a display head. In the event there is no head (ex: a GCP VM), follow the installation steps for setting up Chrome Remote Deskop. This will create a `display` which we can use below 
+1. In a terminal from a remote desktop screen, run `echo $DISPLAY` to get a display id (ex: `:20`)
+2. In a terminal started from your local machine, export the display id (ex: `export DISPLAY=:20`).
+3. In the same terminal, run `xhost+` to give containers access to the display for rendering.  
+4. `chmod +x run.sh && ./run.sh` to build a docker image and enter the container
+5. Additional volumes can be added for mapping in `run.sh`
+
 ### Example Usages
 
 To set up a new terminal, run:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+set -u
+
+# Define the path to the volume you want to mount
+VOLUME_PATH="."
+
+# Build the Docker image. The -t option lets you tag your image so it's easier to find later.
+docker build -t aloha .
+
+# Check if the container exists
+if [ $(docker ps -a -f name=aloha | grep -w aloha | wc -l) -eq 0 ]; then
+    # Create the Docker container
+    docker run --name aloha -d -P -it -v /tmp/.X11-unix:/tmp/.X11-unix -v $VOLUME_PATH:/act-plus-plus --ipc=host --pid=host --network=host --gpus=all -w /act-plus-plus aloha:latest
+fi
+
+# Start the Docker container
+docker start aloha
+
+# Execute command in the Docker container
+docker exec -it aloha /bin/bash 


### PR DESCRIPTION
Adds adds a Dockerfile based on a Pytorch base image along with some simple documentation to help deploy simulated data and training in different host environments. 

Tested remotely on an L4 GCP instance running Ubuntu 20.04 and on a 4090 box running Ubuntu 22.04.  